### PR TITLE
Convert actor sheet descriptions from textarea to tinymce editor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/module/sav-actor-sheet.js
+++ b/module/sav-actor-sheet.js
@@ -14,7 +14,8 @@ export class SaVActorSheet extends SaVSheet {
   	  template: "systems/scum-and-villainy/templates/actor-sheet.html",
       width: 800,
       height: 970,
-      tabs: [{navSelector: ".tabs", contentSelector: ".tab-content", initial: "abilities"}]
+      tabs: [{navSelector: ".tabs", contentSelector: ".tab-content", initial: "abilities"}],
+      scrollY: [".biography"]
     });
   }
 

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -385,12 +385,12 @@
           <div class="item-class-label"><a class="item-add-popup" data-item-type="friend">{{localize "BITD.AddFriend"}}</a></div>
         </div>
       </div>
-	  
+
       <div class="tab flex-vertical" data-tab="character-notes">
         <div class="label-stripe">
           <p>{{localize "BITD.Notes"}}</p>
         </div>
-        <textarea rows="13" name="data.description">{{{data.description}}}</textarea>
+        {{editor content=data.biography target="data.biography" button=true owner=owner editable=editable}}
       </div>
 
       {{!-- Full Item List --}}


### PR DESCRIPTION
I haven't been able to reproduce the issue, but there is a work around for textareas in BladesSheet/SaVSheet that is suspect. Using an editor more closely follows the examples set forth in the simple worldbuilding system.