### PR TITLE
Fix for long faction names (localization)

### DIFF
--- a/module/sav-faction-status-sheet.js
+++ b/module/sav-faction-status-sheet.js
@@ -9,7 +9,7 @@ export class SaVFactionStatusSheet extends SaVSheet {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["scum-and-villainy", "sheet", "actor", "fs-faction-dialog"],
       template: "systems/scum-and-villainy/templates/faction-status-sheet.hbs",
-      width: 1250,
+      width: 1280,
       height: "auto",
       resizable: false,
       tabs: [{ navSelector: ".tabs", contentSelector: ".tab-content" }],

--- a/styles/sav.css
+++ b/styles/sav.css
@@ -491,7 +491,7 @@
 * #all-items .item-name {
 	width: 300px;
 }
-* #faction-items .item-name {
+* #faction-items .item-name:not(.fs-faction-name) {
   width: 120px;
 }
 * #friend-list .item .item-body {
@@ -1982,15 +1982,20 @@ padding: 0px;
 
 .fs-column-faction-name {
   display: flex;
-  flex:0 0 140px;
-  width: 140px;
+  flex:0 0 150px;
+  width: 150px;
   align-items: center;
   margin:0px;
   padding-left: 4px;
+  padding-right:4px;
 }
 
 .fs-faction-name{
-  width: 140px;
+  width: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* Number of lines to show */
+  -webkit-box-orient: vertical;
 }
 
 .fs-tooltip-fix{


### PR DESCRIPTION
- increased width of faction-status window
- increased width of name field, and limited it to 2 lines max with ellipsis truncation

--found a small bug with the "select-items" dialog.  If you have a really long item name (over ~64chars) the line will wrap and overlap with the text below.  Seems like an edge case, but changing the ".flex-horizontal" style to truncate the text has all kinds of impact as it is widely used, so i did not touch.