### PR TITLE
 Get speaker alias from actor sheet when possible

### DIFF
--- a/module/sav-actor.js
+++ b/module/sav-actor.js
@@ -385,6 +385,7 @@ export class SaVActor extends Actor {
 
   async rollAttribute( attribute_name = "", additional_dice_amount = 0, position, effect ) {
     let dice_amount = 0;
+    let speaker_name = this.name;
 
     if ( attribute_name !== "" ) {
       let roll_data = this.getRollData();
@@ -395,7 +396,7 @@ export class SaVActor extends Actor {
     }
     dice_amount += additional_dice_amount;
 
-    await savRoll( dice_amount, attribute_name, position, effect );
+    await savRoll( dice_amount, attribute_name, position, effect, "", speaker_name );
   }
 
   /* -------------------------------------------- */

--- a/module/sav-roll.js
+++ b/module/sav-roll.js
@@ -5,8 +5,9 @@
  * @param {string} position
  * @param {string} effect
  * @param {string} purpose
+ * @param {string} speaker_name
  */
-export async function savRoll(dice_amount, attribute_name = "", position = "risky", effect = "standard", purpose = "") {
+export async function savRoll(dice_amount, attribute_name = "", position = "risky", effect = "standard", purpose = "", speaker_name = "") {
 
   let zeromode = false;
 
@@ -17,7 +18,7 @@ export async function savRoll(dice_amount, attribute_name = "", position = "risk
 
   await r.evaluate({async: true});
 
-  await showChatRollMessage( r, zeromode, attribute_name, position, effect, purpose );
+  await showChatRollMessage( r, zeromode, attribute_name, position, effect, purpose, speaker_name );
 }
 
 /**
@@ -29,10 +30,12 @@ export async function savRoll(dice_amount, attribute_name = "", position = "risk
  * @param {string} position
  * @param {string} effect
  * @param {string} purpose
+ * @param {string} speaker_name
  */
-async function showChatRollMessage(r, zeromode, attribute_name = "", position = "", effect = "", purpose = "") {
+async function showChatRollMessage(r, zeromode, attribute_name = "", position = "", effect = "", purpose = "", speaker_name = "") {
 
   let speaker = ChatMessage.getSpeaker();
+  if( speaker_name ) { speaker.alias = speaker_name }
   let rolls = (r.terms)[0].results;
   let attribute_label;
   if( attribute_name === "fortune"){


### PR DESCRIPTION
- When clicking a roll from a character sheet, speaker alias should default to sheet actor
- Useful for cases when GM selects a roll or when playing multiple actors at once