### PR TITLE
[fix] token vison, disposition, and actorlink via mergeObject

### DIFF
--- a/module/sav-actor.js
+++ b/module/sav-actor.js
@@ -40,10 +40,17 @@ export class SaVActor extends Actor {
   /** @override */
   static async create(data, options={}) {
     if( !data.icon || !data.token ) {
-      data.prototypeToken = data.prototypeToken || {};
-      data.prototypeToken.actorLink = true;
-      data.prototypeToken.name = data.name;
-      data.prototypeToken.displayName = 50;
+      data.prototypeToken = foundry.utils.mergeObject(
+        data.prototypeToken || {}, 
+        {
+          actorLink: true,
+          displayName: 50,
+          sight: {
+            enabled: true
+          },
+        },
+        { overwrite: false }
+      )
     }
 
     await super.create(data, options);
@@ -59,6 +66,7 @@ export class SaVActor extends Actor {
     if( createData.type === "character" ) {
       const playbookXP = game.settings.get( "scum-and-villainy", "defaultPlaybookXPBarSize" );
       const attributeXP = game.settings.get( "scum-and-villainy", "defaultAttributeXPBarSize" );
+      updateData['prototypeToken.disposition'] = 1;
 
       if( playbookXP ) {
         updateData['system.experienceMax'] = playbookXP;
@@ -76,6 +84,7 @@ export class SaVActor extends Actor {
 
     if( createData.type === "ship" ) {
       const crewXP = game.settings.get( "scum-and-villainy", "defaultCrewXPBarSize" );
+      updateData['prototypeToken.disposition'] = 1;
 
       if( crewXP ) {
         updateData['system.crew_experienceMax'] = crewXP;


### PR DESCRIPTION
https://github.com/drewg13/foundryvtt-scum-and-villainy/issues/89
`tokenVision` needs to be enabled. I found a couple other bugs while poking around. Thanks for maintaining!

![image](https://github.com/user-attachments/assets/c22d7ee2-2cfd-416e-bc10-0c343ed6892d)

